### PR TITLE
Fix build for ghc 7.10

### DIFF
--- a/ide-backend-client.cabal
+++ b/ide-backend-client.cabal
@@ -29,13 +29,13 @@ executable ide-backend-client
                        -- introduce a shim.
                        Cabal                >= 1.22 && < 1.23,
                        directory            >= 1.2  && < 1.3,
-                       filepath             >= 1.3  && < 1.4,
+                       filepath             >= 1.3  && < 1.5,
                        ide-backend          >= 0.9  && < 1.0,
                        JsonGrammar          >= 1.0  && < 1.1,
                        language-typescript  >= 0.0  && < 0.1,
                        optparse-applicative >= 0.11 && < 0.12,
                        stack-prism          >= 0.1  && < 0.2,
-                       text                 >= 1.1  && < 1.2,
+                       text                 >= 1.1  && < 1.3,
                        utf8-string          >= 0.3  && < 0.4
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/IdeSession/Client.hs
+++ b/src/IdeSession/Client.hs
@@ -32,7 +32,7 @@ main = do
       putEnc =<< listTargets fp
 
 startEmptySession :: Options -> EmptyOptions -> IO ()
-startEmptySession Options{..} EmptyOptions{..} =
+startEmptySession Options{..} EmptyOptions =
     bracket (initSession optInitParams optConfig)
             shutdownSession
             mainLoop

--- a/src/IdeSession/Client/JsonAPI.hs
+++ b/src/IdeSession/Client/JsonAPI.hs
@@ -22,6 +22,7 @@
 -- stable, and well documented.
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE KindSignatures #-}
 module IdeSession.Client.JsonAPI (
     -- * Requests
     Request(..)


### PR DESCRIPTION
It looks like record wildcards for types with no named fields work no longer (obviously they are not useful anyway). Also KindSignatures are necessary because they get infered somewhere.
