### PR TITLE
Disable stdout/stderr buffering for Sublime Text/Python

### DIFF
--- a/ide-backend-client/app/main.hs
+++ b/ide-backend-client/app/main.hs
@@ -27,7 +27,7 @@ main = do
     StartEmptySession opts' -> startEmptySession clientIO opts opts'
 #ifdef USE_CABAL
     StartCabalSession opts' -> startCabalSession clientIO opts opts'
-    ListTargets opts' -> sendTargetsList clientIO opts opts'
+    ListTargets filepath -> sendTargetsList clientIO filepath
 #else
     StartCabalSession _ -> notBuiltWithCabal
     ListTargets _ -> notBuiltWithCabal

--- a/ide-backend-client/app/main.hs
+++ b/ide-backend-client/app/main.hs
@@ -8,10 +8,13 @@ import IdeSession.Client
 import IdeSession.Client.CmdLine
 import IdeSession.Client.JsonAPI (apiDocs, toJSON, fromJSON)
 import IdeSession.Client.Util.ValueStream (newStream, nextInStream)
-import System.IO (stdin, stdout)
+import System.IO (stdin, stdout, stderr, hSetBuffering, BufferMode(..))
 
 main :: IO ()
 main = do
+  hSetBuffering stdout NoBuffering
+  hSetBuffering stderr NoBuffering
+
   input <- newStream stdin
   -- We separate JSON values in the output by newlines, so that
   -- editors have a means to split the input into separate

--- a/ide-backend-client/src/IdeSession/Client.hs
+++ b/ide-backend-client/src/IdeSession/Client.hs
@@ -34,10 +34,7 @@ import IdeSession.Client.JsonAPI
 import IdeSession.Client.Cabal
 #endif
 
-data ClientIO = ClientIO
-    { sendResponse :: Response -> IO ()
-    , receiveRequest :: IO (Either String Request)
-    }
+
 
 startEmptySession :: ClientIO -> Options -> EmptyOptions -> IO ()
 startEmptySession clientIO Options{..} EmptyOptions = do
@@ -50,14 +47,14 @@ startEmptySession clientIO Options{..} EmptyOptions = do
 startCabalSession :: ClientIO -> Options -> CabalOptions -> IO ()
 startCabalSession clientIO options cabalOptions = do
     sendWelcome clientIO
-    bracket (initCabalSession options cabalOptions)
+    bracket (initCabalSession clientIO options cabalOptions)
             shutdownSession
             (mainLoop clientIO)
 
 sendTargetsList :: ClientIO -> FilePath -> IO ()
 sendTargetsList clientIO fp = do
     sendWelcome clientIO
-    sendResponse clientIO =<< listTargets fp
+    sendResponse clientIO . ResponseListTargets =<< listTargets fp
 #endif
 
 sendWelcome :: ClientIO -> IO ()

--- a/ide-backend-client/src/IdeSession/Client/Cabal.hs
+++ b/ide-backend-client/src/IdeSession/Client/Cabal.hs
@@ -32,8 +32,8 @@ listTargets cabalRoot = do
     lbi <- getPersistBuildConfig (cabalRoot </> "dist")
     return $ availableTargets lbi
 
-initCabalSession :: Options -> CabalOptions -> IO IdeSession
-initCabalSession Options{..} CabalOptions{..} = do
+initCabalSession :: ClientIO -> Options -> CabalOptions -> IO IdeSession
+initCabalSession ClientIO{..} Options{..} CabalOptions{..} = do
     lbi <- getPersistBuildConfig (cabalRoot </> "dist")
     (comp, clbi, exts) <- resolveBuildTarget lbi cabalTarget
     mods <- componentModules cabalRoot comp
@@ -48,8 +48,8 @@ initCabalSession Options{..} CabalOptions{..} = do
     session <- initSession initParams config
     setGhcOpts session exts
     let loadModules = mconcat $ map updateSourceFileFromFile mods
-    updateSession session loadModules (putEnc . ResponseUpdateSession . Just)
-    putEnc $ ResponseUpdateSession Nothing
+    updateSession session loadModules (sendResponse . ResponseUpdateSession . Just)
+    sendResponse $ ResponseUpdateSession Nothing
     -- dumpIdInfo session
     return session
   where

--- a/ide-backend-client/src/IdeSession/Client/CmdLine.hs
+++ b/ide-backend-client/src/IdeSession/Client/CmdLine.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 module IdeSession.Client.CmdLine (
     -- * Types
-    Options(..)
+    ClientIO(..)
+  , Options(..)
   , Command(..)
   , EmptyOptions(..)
   , CabalOptions(..)
@@ -18,10 +19,16 @@ import qualified Options.Applicative.Help.Chunk as Chunk
 import qualified Text.PrettyPrint.ANSI.Leijen   as Doc
 
 import IdeSession
+import IdeSession.Client.JsonAPI
 
 {-------------------------------------------------------------------------------
   Types
 -------------------------------------------------------------------------------}
+
+data ClientIO = ClientIO
+    { sendResponse :: Response -> IO ()
+    , receiveRequest :: IO (Either String Request)
+    }
 
 data Options = Options {
     optInitParams :: SessionInitParams

--- a/ide-backend-json/src/IdeSession/Client/JsonAPI.hs
+++ b/ide-backend-json/src/IdeSession/Client/JsonAPI.hs
@@ -113,6 +113,7 @@ data RequestSessionUpdate =
 data Response =
     -- | Sent on session initialization
     ResponseWelcome VersionInfo
+  | ResponseListTargets [String]
     -- | Nothing indicates the update completed
   | ResponseUpdateSession (Maybe Progress)
   | ResponseGetSourceErrors [SourceError]
@@ -340,6 +341,9 @@ instance Json Response where
           property "response" "welcome"
         . fromPrism responseWelcome
         . prop "version"
+      ,   property "response" "listTargets"
+        . fromPrism responseListTargets
+        . prop "targets"
       ,   property "response" "sessionUpdate"
         . fromPrism responseUpdateSession
         . optProp "progress"

--- a/ide-backend-json/src/IdeSession/Client/JsonAPI/Common.hs
+++ b/ide-backend-json/src/IdeSession/Client/JsonAPI/Common.hs
@@ -44,6 +44,7 @@ iso f g = top (stackPrism f (Just . g))
 instance Json String          where grammar = string
 instance Json Lazy.ByteString where grammar = lazyByteString
 instance Json BS.ByteString   where grammar = bytestring
+instance Json Bool            where grammar = boolean
 
 -- | Define a grammar by enumerating the possible values
 --
@@ -67,6 +68,9 @@ lazyByteString = fromPrism (iso Lazy.fromString Lazy.toString) . grammar
 -- | Strict bytestring literal
 bytestring :: Grammar Val (Value :- t) (BS.ByteString :- t)
 bytestring = fromPrism (iso BS.fromString BS.toString) . grammar
+
+boolean :: Grammar Val (Value :- t) (Bool :- t)
+boolean = enumeration [(True, "true"), (False, "false")]
 
 -- | Optional property
 optProp :: Json a => Text -> Grammar Obj t (Maybe a :- t)


### PR DESCRIPTION
Yo!

A heads up — I put together a Sublime Text 3 plugin over the weekend based on ide-backed/client and it is just crazy fast and wonderful (even with just autocomplete, error regions and type-at-cursor it already blows away SublimeHaskell for me!). Thanks a ton for all the work.

https://github.com/lukexi/Rawhide

I had to disable buffering on stdout/stderr along with the other pull request to get Python's subprocess.Popen to receive things reliably from the ide-backend-client executable; I can put together a minimal repro if you want try finding another way (I tried just calling hFlush after hPutStrLn and screwing around with every option I could find in Popen, this was the only thing that worked).
