### PR TITLE
CLI option to disable stdout buffering for use in pipelined mode

### DIFF
--- a/ide-backend-client/app/main.hs
+++ b/ide-backend-client/app/main.hs
@@ -2,13 +2,14 @@
 
 module Main where
 
+import Control.Monad (when)
 import Data.Aeson (encode)
 import Data.ByteString.Lazy.Char8 (hPutStrLn)
 import IdeSession.Client
 import IdeSession.Client.CmdLine
 import IdeSession.Client.JsonAPI (apiDocs, toJSON, fromJSON)
 import IdeSession.Client.Util.ValueStream (newStream, nextInStream)
-import System.IO (stdin, stdout)
+import System.IO (stdin, stdout, hSetBuffering, BufferMode(..))
 
 main :: IO ()
 main = do
@@ -22,6 +23,7 @@ main = do
         , receiveRequest = fmap fromJSON $ nextInStream input
         }
   opts <- getCommandLineOptions
+  when (bufferIO $ optIFConfig opts) $ hSetBuffering stdout NoBuffering
   case optCommand opts of
     ShowAPI -> putStrLn apiDocs
     StartEmptySession opts' -> startEmptySession clientIO opts opts'

--- a/ide-backend-client/ide-backend-client.cabal
+++ b/ide-backend-client/ide-backend-client.cabal
@@ -14,7 +14,7 @@ cabal-version:       >=1.10
 
 flag use-cabal
   description: Enable ide-backend-client cabal support
-  default: True
+  default: False
 
 library
   hs-source-dirs:      src
@@ -35,7 +35,7 @@ library
                        JsonGrammar          >= 1.0  && < 1.1,
                        aeson                >= 0.7  && < 0.9,
                        ansi-wl-pprint       >= 0.6  && < 0.7,
-                       attoparsec           >= 0.12 && < 0.13,
+                       attoparsec           >= 0.12,
                        bytestring           >= 0.10 && < 0.11,
                        directory            >= 1.2  && < 1.3,
                        filepath             >= 1.3  && < 1.5,

--- a/ide-backend-client/src/IdeSession/Client/CmdLine.hs
+++ b/ide-backend-client/src/IdeSession/Client/CmdLine.hs
@@ -4,6 +4,7 @@ module IdeSession.Client.CmdLine (
     Options(..)
   , Command(..)
   , EmptyOptions(..)
+  , InterfaceConfig(..)
   , CabalOptions(..)
     -- * Parsing
   , getCommandLineOptions
@@ -26,6 +27,7 @@ import IdeSession
 data Options = Options {
     optInitParams :: SessionInitParams
   , optConfig     :: SessionConfig
+  , optIFConfig   :: InterfaceConfig
   , optCommand    :: Command
   }
   deriving Show
@@ -39,6 +41,10 @@ data Command =
 
 data EmptyOptions = EmptyOptions
   deriving Show
+
+data InterfaceConfig = InterfaceConfig {
+    bufferIO :: Bool
+  } deriving Show
 
 data CabalOptions = CabalOptions {
     cabalTarget :: String
@@ -54,6 +60,7 @@ parseOptions :: Parser Options
 parseOptions = Options
   <$> parseInitParams
   <*> parseConfig
+  <*> parseIFConfig
   <*> parseCommand
 
 parseCommand :: Parser Command
@@ -71,6 +78,13 @@ parseCommand = subparser $ mconcat [
         (helper <*> pure ShowAPI)
         (progDesc "Show the JSON API documentation")
     ]
+
+parseIFConfig :: Parser InterfaceConfig
+parseIFConfig = InterfaceConfig
+    <$> (flag False True $ mconcat [
+          long "unbuffered"
+        , help "Do not buffer stdout (useful for piping with interactive environments)"
+        ])
 
 parseEmptyOptions :: Parser EmptyOptions
 parseEmptyOptions = pure EmptyOptions

--- a/ide-backend-json/src/IdeSession/Client/JsonAPI/Common.hs
+++ b/ide-backend-json/src/IdeSession/Client/JsonAPI/Common.hs
@@ -42,6 +42,7 @@ iso f g = top (stackPrism f (Just . g))
 -------------------------------------------------------------------------------}
 
 instance Json String          where grammar = string
+instance Json Bool            where grammar = bool
 instance Json Lazy.ByteString where grammar = lazyByteString
 instance Json BS.ByteString   where grammar = bytestring
 
@@ -59,6 +60,9 @@ enumeration = mconcat . map aux
 -- | String literal
 string :: Grammar Val (Value :- t) (String :- t)
 string = fromPrism (iso Text.unpack Text.pack) . grammar
+
+bool :: Grammar Val (Value :- t) (Bool :- t)
+bool = enumeration [(True, "true"), (False, "false")]
 
 -- | Lazy bytestring literal
 lazyByteString :: Grammar Val (Value :- t) (Lazy.ByteString :- t)


### PR DESCRIPTION
First two commits are only to make the client compile (e.g. putEnc is no longer defined anywhere, attoparsec dependency was rather tight).

Tried to use this client in a Java (ProcessBuilder) program and didn't receive output; this is expected buffered pipelining behaviour, but for interactive use, it's rather in the way.
