### PR TITLE
Add RequestSessionUpdate

### DIFF
--- a/stack-ide-api/src/Stack/Ide/JsonAPI.hs
+++ b/stack-ide-api/src/Stack/Ide/JsonAPI.hs
@@ -85,6 +85,7 @@ data Request =
 -- | Session updates
 data RequestSessionUpdate
   = RequestUpdateTargets Targets
+  | RequestSessionUpdate -- Simply calls updateSession with no changes to trigger a recompile.
 
 -- TODO:
 -- RequestUpdateGhcOpts [String]

--- a/stack-ide/src/Stack/Ide.hs
+++ b/stack-ide/src/Stack/Ide.hs
@@ -204,6 +204,8 @@ idInfoToAutocompletion IdInfo{idProp = IdProp{idName, idDefinedIn, idType}, idSc
 makeSessionUpdate :: RequestSessionUpdate -> IdeSessionUpdate
 makeSessionUpdate (RequestUpdateTargets targets) =
   updateTargets targets
+makeSessionUpdate (RequestSessionUpdate) =
+  mempty
 
 -- TODO:
 {-makeSessionUpdate (RequestUpdateSourceFile filePath contents) =

--- a/stack-ide/src/main/Main.hs
+++ b/stack-ide/src/main/Main.hs
@@ -10,7 +10,7 @@ import Stack.Ide
 import Stack.Ide.CmdLine
 import Stack.Ide.JsonAPI ()
 import Stack.Ide.Util.ValueStream (newStream, nextInStream)
-import System.IO (stdin, stdout)
+import System.IO (stdin, stdout, stderr, hSetBuffering, BufferMode(..))
 
 main :: IO ()
 main = do
@@ -25,4 +25,8 @@ main = do
         }
         where fromJSON = parseEither parseJSON
   opts <- getCommandLineOptions
+  
+  -- Disable buffering for interactive piping
+  mapM_ (flip hSetBuffering NoBuffering) [stdout, stderr]
+  
   startEmptySession clientIO opts


### PR DESCRIPTION
OK, I've got the stackified Sublime Text plugin up and running at https://github.com/lukexi/stack-ide-sublime/.
It looks like Sublime Text's package manager requires packages to be at the root of their repository, so I didn't add it here. We could move the repo to the commercialhaskell umbrella, though.

I added an API call that triggers updateSession to work with the local-working-dir mode.

I'm sticking with just disabling buffering globally here rather than complicating things with a flag; let me know if you'd rather go with the flag approach (it would need to be plumbed through to stack's ide command as well).

There's also a small update needed to stack here to support the API call; I'll put it into a pull request for stack if everything above looks good.
https://github.com/lukexi/stack/commit/73c71445064525b8fe98cd0fea6b47b4d1d1cf4d
