### PR TITLE
[Install instructions] Remove extra space after \ and ease copy pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install with:
     $ cd stack-ide
     $ stack install \
         stack-ide \
-        stack-ide-api \ 
+        stack-ide-api \
         ../ide-backend/ide-backend \
         ../ide-backend/ide-backend-rts \
         ../ide-backend/ide-backend-server \

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This is currently a work in progress. Patches welcome.
 
 Install with:
 
-    $ git clone git@github.com:fpco/ide-backend.git
-    $ git clone git@github.com:commercialhaskell/stack-ide.git
-    $ cd stack-ide
-    $ stack install \
+    git clone git@github.com:fpco/ide-backend.git
+    git clone git@github.com:commercialhaskell/stack-ide.git
+    cd stack-ide
+    stack install \
         stack-ide \
         stack-ide-api \
         ../ide-backend/ide-backend \


### PR DESCRIPTION
The extra space caused the command to finish  after the third line, causing the install to fail when simply copy-pasting the instruction
