### PR TITLE
Clone using https instead of git-protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This is currently a work in progress. Patches welcome.
 
 Install with:
 
-    $ git clone git@github.com:fpco/ide-backend.git
-    $ git clone git@github.com:commercialhaskell/stack-ide.git
+    $ git clone https://github.com/fpco/ide-backend.git
+    $ git clone https://github.com/commercialhaskell/stack-ide.git
     $ cd stack-ide
     $ stack install \
         stack-ide \


### PR DESCRIPTION
I assume most people cloning this will not have access to the repo, so using https might be more appropriate
