### PR TITLE
Optional seq field accepted in requests and then quoted in responses

### DIFF
--- a/stack-ide-api/stack-ide-api.cabal
+++ b/stack-ide-api/stack-ide-api.cabal
@@ -19,6 +19,7 @@ library
   build-depends:       base                 >= 4.5  && < 5,
                        ide-backend-common   >= 0.10 && < 0.11,
                        aeson                >= 0.7  && < 0.9,
+                       unordered-containers >= 0.1  && < 0.3,
                        bytestring           >= 0.10 && < 0.11,
                        text                 >= 1.1  && < 1.3
   default-language:    Haskell2010

--- a/stack-ide/src/main/Main.hs
+++ b/stack-ide/src/main/Main.hs
@@ -13,7 +13,7 @@ import Data.ByteString.Lazy.Char8 (toStrict)
 import Data.Text.Encoding (decodeUtf8)
 import Stack.Ide
 import Stack.Ide.CmdLine
-import Stack.Ide.JsonAPI (Response(ResponseLog))
+import Stack.Ide.JsonAPI (Response(ResponseLog), Sequenced(NoSeq))
 import Stack.Ide.Util.ValueStream (newStream, nextInStream)
 import System.IO (stdin, stdout, stderr, hSetBuffering, BufferMode(..))
 import System.Log.FastLogger (fromLogStr)
@@ -37,7 +37,7 @@ main = do
       -- Ideally this wouldn't roundtrip through Utf8 encoding, but ohwell.
       logMessage loc source level str =
         when (optVerbose opts) $
-          sendResponse $ ResponseLog $ decodeUtf8 $ fromLogStr $ defaultLogStr loc source level str
+          sendResponse $ NoSeq $ ResponseLog $ decodeUtf8 $ fromLogStr $ defaultLogStr loc source level str
       clientIO = ClientIO {..}
 
   -- Disable buffering for interactive piping


### PR DESCRIPTION
Implements the proposal in #39, namely, every request accepts an additional field `seq`, whose value can be any JSON value and if present, it is included in a field `seq` of every response associated to the request. Clients that include no `seq` field in their requests will get no `seq` field in their responses.

This increments the protocol version to 0.1.0.
