### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,14 @@ This is currently a work in progress. Patches welcome.
 
 Install with:
 
-    git clone https://github.com/fpco/ide-backend.git
-    git clone https://github.com/commercialhaskell/stack-ide.git
+    git clone --recursive https://github.com/commercialhaskell/stack-ide.git
     cd stack-ide
     stack install \
         stack-ide \
         stack-ide-api \
-        ../ide-backend/ide-backend \
-        ../ide-backend/ide-backend-server \
-        ../ide-backend/ide-backend-common
+        ide-backend/ide-backend \
+        ide-backend/ide-backend-server \
+        ide-backend/ide-backend-common
 
 GHC 7.10 has some GHC API bug fixes which show up in ide-backend in
 GHC 7.8, so the `stack.yaml` references a nightly Stackage build which

--- a/README.md
+++ b/README.md
@@ -10,12 +10,7 @@ Install with:
 
     git clone --recursive https://github.com/commercialhaskell/stack-ide.git
     cd stack-ide
-    stack install \
-        stack-ide \
-        stack-ide-api \
-        ide-backend/ide-backend \
-        ide-backend/ide-backend-server \
-        ide-backend/ide-backend-common
+    stack install
 
 GHC 7.10 has some GHC API bug fixes which show up in ide-backend in
 GHC 7.8, so the `stack.yaml` references a nightly Stackage build which

--- a/travis_long
+++ b/travis_long
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+$* &
+pidA=$!
+minutes=0
+
+while true; do sleep 60; ((minutes++)); echo -e "\033[0;32m$minutes minute(s) elapsed.\033[0m"; done &
+	pidB=$!
+
+	wait $pidA
+        exitCode=$?
+
+	echo -e "\033[0;32m$* finished.\033[0m"
+
+	kill -9 $pidB
+
+        exit $exitCode


### PR DESCRIPTION
Since we moved `ide-backend` to submodule, we don't need to explicitly
clone it.
