### PR TITLE
seems to need json.el?

### DIFF
--- a/stack-mode/stack-mode.el
+++ b/stack-mode/stack-mode.el
@@ -27,6 +27,7 @@
 (require 'checklist)
 (require 'flycheck)
 (require 'popup)
+(require 'json)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Modes


### PR DESCRIPTION
This started working for me when I added (require 'json) to my init.el - that's where all the json-encode functions come from, i think?
