### PR TITLE
stack-mode-info wants to display the package name but is showing the key

### DIFF
--- a/stack-mode/stack-mode.el
+++ b/stack-mode/stack-mode.el
@@ -325,14 +325,14 @@ Run `M-x stack-mode-list-loaded-modules' to see what's loaded.")))
          (moduleName (stack-lookup 'moduleName idDefinedIn))
          (packageVersion (stack-lookup 'packageVersion modulePackage))
          (packageKey (stack-lookup 'packageKey modulePackage))
-         (packageName (stack-lookup 'packageKey modulePackage))
+         (packageName (stack-lookup 'packageName modulePackage))
          (idType (stack-lookup 'idType prop))
          (idName (stack-lookup 'idName prop)))
     (let ((info-string (concat
                         "Identifier: " (haskell-fontify-as-mode idName 'haskell-mode) "\n"
                         "Type: " (haskell-fontify-as-mode idType 'haskell-mode) "\n"
                         "Module: " (haskell-fontify-as-mode moduleName 'haskell-mode) "\n"
-                        "Package: "  (if (string= "main" packageName)
+                        "Package: "  (if (string= "main" packageKey)
                                          "(this one)"
                                        packageName))))
       (cond ((and stack-mode-show-popup (fboundp 'popup-tip))


### PR DESCRIPTION
With current GHCs, the package keys are a short prefix of the package
name plus a hash, which isn't a very useful thing to show to a human, and
it's clear from the code the name is intended.

Later on it compared the packageName value against with "main" to decide
whether the package should be shown as "(this one)".  That works too
because both the key and name are returned from ide-backend as "main",
but I've changed it to use the key because I think it won't break if someone
ever creates a package called "main".
